### PR TITLE
CLN: cleanup pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Astronomy",
-    "Typing :: Typed",
 ]
 requires-python = ">=3.10"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,18 +2,16 @@
 requires = ["flit_core >=3.11,<4"]
 build-backend = "flit_core.buildapi"
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/oimalib"]
-
 [project]
 name = "oimalib"
 version = "0.3"
 description = "Optical Interferometry Modelling and Analysis Library"
 authors = [{ name = "Anthony Soulain", email = "anthony.soulain@oca.eu" }]
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: AIX",
     "Operating System :: POSIX :: Linux",
@@ -45,20 +43,16 @@ dependencies = [
 [project.scripts]
 oimalib = "oimalib._cli:main"
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=8",
-    "coverage>=7",
-    "ruff>=0.6.0",
-    "basedpyright>=1.19.0",
-    "ipykernel",
-    "pre-commit",
-]
-
 [dependency-groups]
 typecheck = ["mypy>=1.14.1", "types-termcolor>=1.1.6.2"]
 test = ["pytest>=8", "pytest-cov", "coverage"]
-lint = ["ruff>=0.6.0", "basedpyright>=1.19.0"]
+lint = ["ruff>=0.6.0", "basedpyright>=1.19.0", "pre-commit"]
+dev = [
+    { include-group = "typecheck" },
+    { include-group = "test" },
+    { include-group = "lint" },
+        "ipykernel",
+]
 
 [project.urls]
 Homepage = "https://github.com/DrSoulain/oimalib"
@@ -67,20 +61,6 @@ Issues = "https://github.com/DrSoulain/oimalib/issues"
 [project.readme]
 file = "README.md"
 content-type = "text/markdown"
-
-[tool.setuptools]
-license-files = ["LICENSE"]
-include-package-data = false
-
-[tool.setuptools.packages.find]
-exclude = ["tests*", "doc*"]
-namespaces = false
-
-[tool.setuptools.package-data]
-oimalib = ["internal_data/*.fits"]
-
-[tool.black]
-line-length = 88
 
 [tool.ruff]
 line-length = 100
@@ -99,7 +79,7 @@ known-first-party = ["oimalib"]
 
 [tool.basedpyright]
 typeCheckingMode = "standard"
-pythonVersion = "3.11"
+pythonVersion = "3.10"
 reportMissingTypeStubs = "warning"
 venvPath = "."
 venv = ".venv"


### PR DESCRIPTION
- remove unused tables (hatch, setuptools, black)
- replace deprecated PyPI trove classifier with PEP 639 license metadata
- adjust a couple inconsistencies